### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/zofware/380761ef-c3e3-4429-b76d-6b4daa3c44bd/1210d0e4-380a-4d08-aebc-8f464142b12a/_apis/work/boardbadge/1cf9694e-2c4e-493d-88d0-54c7c2dfe2ec)](https://dev.azure.com/zofware/380761ef-c3e3-4429-b76d-6b4daa3c44bd/_boards/board/t/1210d0e4-380a-4d08-aebc-8f464142b12a/Microsoft.FeatureCategory)
 # SimpleSportsCaster
 Public discussion of issues and feedback for [SimpleSportsCaster](https://www.simplesportscaster.com).


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#122](https://dev.azure.com/zofware/380761ef-c3e3-4429-b76d-6b4daa3c44bd/_workitems/edit/122). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.